### PR TITLE
Expose error text and status code

### DIFF
--- a/src/clients/elastic-angular-client.js
+++ b/src/clients/elastic-angular-client.js
@@ -23,8 +23,8 @@ angular.module('elasticjs.service', [])
           (successcb || angular.noop)(response.data);
           return response.data;
         }, function (response) {
-          (errorcb || angular.noop)(undefined);
-          return undefined;
+          (errorcb || angular.noop)(response.data);
+          return response.data;
         });
       };
 


### PR DESCRIPTION
I suspect undefined was being passed to errorcb to maintain backward compatibility with code that was checking if the results were undefined and assuming an error from that. I dunno if its worth the breaking change, but I needed to be able to see the error text
