### PR TITLE
Fix documentation; "OR" is not Google's default operator

### DIFF
--- a/dist/elastic.js
+++ b/dist/elastic.js
@@ -10848,7 +10848,7 @@
 
             <p>This operator is used to join individual query terms when no operator is 
             explicity used in the query string (i.e., <code>this AND that</code>).
-            Defaults to <code>OR</code> (<em>same as Google</em>).</p>
+            Defaults to <code>OR</code>.</p>
 
             @member ejs.FieldQuery
             @param {String} op The operator, AND or OR.
@@ -15078,7 +15078,7 @@
       /**
             Set the default <em>Boolean</em> operator. This operator is used to join individual query
             terms when no operator is explicity used in the query string (i.e., <code>this AND that</code>).
-            Defaults to <code>OR</code> (<em>same as Google</em>).
+            Defaults to <code>OR</code>.
 
             @member ejs.QueryStringQuery
             @param {String} op The operator to use, AND or OR.

--- a/src/query/FieldQuery.js
+++ b/src/query/FieldQuery.js
@@ -70,7 +70,7 @@
 
             <p>This operator is used to join individual query terms when no operator is 
             explicity used in the query string (i.e., <code>this AND that</code>).
-            Defaults to <code>OR</code> (<em>same as Google</em>).</p>
+            Defaults to <code>OR</code>.</p>
 
             @member ejs.FieldQuery
             @param {String} op The operator, AND or OR.

--- a/src/query/QueryStringQuery.js
+++ b/src/query/QueryStringQuery.js
@@ -114,7 +114,7 @@
       /**
             Set the default <em>Boolean</em> operator. This operator is used to join individual query
             terms when no operator is explicity used in the query string (i.e., <code>this AND that</code>).
-            Defaults to <code>OR</code> (<em>same as Google</em>).
+            Defaults to <code>OR</code>.
 
             @member ejs.QueryStringQuery
             @param {String} op The operator to use, AND or OR.


### PR DESCRIPTION
ElasticSearch uses _OR_ as the [default operator](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html) for a `query_string` query if no operator is specified.

The elasticjs documentation says that this is the "same as Google". This is not true; Google uses AND as its default Boolean operator.

For example, see [Google Advanced Search](http://www.google.com/advanced_search) which requires "OR" to be typed for an OR query, but will search for "all these words" (i.e., an AND query) if no operator is used.
