### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "url": "https://github.com/fullscale/elastic.js/blob/master/AUTHORS"
   },
   "files": [
-    "elastic-node-client.js",
-    "elastic.js"
+    "dist"
   ],
   "main": "elastic.js",
   "scripts": {


### PR DESCRIPTION
Currently this is uninstallable via NPM.  The issue is that the package does not actually include the dist folder.  This adds it, with the side effect that you use it as so:

```
var elasticSearch = require('elastic.js');
var nc  = require('elastic.js/dist/elastic-node-client');
```

If this is not intended, we'll have to change things around a bit.
