### PR TITLE
Added promise support to node client

### DIFF
--- a/dist/elastic-node-client.js
+++ b/dist/elastic-node-client.js
@@ -1,4 +1,4 @@
-/*! elastic.js - v1.1.1 - 2013-11-13
+/*! elastic.js - v1.1.1 - 2013-12-15
  * https://github.com/fullscale/elastic.js
  * Copyright (c) 2013 FullScale Labs, LLC; Licensed MIT */
 
@@ -15,7 +15,8 @@
     http = require('http'),
     https = require('https'),
     querystring = require('querystring'),
-    
+    Promise = require('bluebird'),
+
     // save reference to global object
     // `window` in browser
     // `exports` on server
@@ -274,8 +275,9 @@
             */
       get: function (path, data, successcb, errorcb) {
         var req,
-            opt = getOptions();
-          
+            opt = getOptions(),
+            deferred = Promise.defer();
+
         opt.host = host;
         opt.port = port;
         opt.path = getPath(path) + '?' + querystring.stringify(data);
@@ -290,19 +292,19 @@
           });
 
           res.on('end', function () {
-            if (successcb != null) {
-              successcb(JSON.parse(resData));
-            }
+            (successcb || deferred.resolve).call(deferred, JSON.parse(resData));
           });
-          
+
         });
-        
+
         // handle request errors
-        if (errorcb != null) {
-          req.on('error', errorcb);
-        }
-        
+        req.on('error', function(error) {
+          (errorcb || deferred.reject).call(deferred, error);
+        });
+
         req.end();
+
+        return deferred.promise;
       },
       
       /**
@@ -318,8 +320,9 @@
             */
       post: function (path, data, successcb, errorcb) {
         var req,
-            opt = getOptions();
-        
+            opt = getOptions(),
+            deferred = Promise.defer();
+
         opt.host = host;
         opt.port = port;
         opt.path = getPath(path);
@@ -334,20 +337,20 @@
           });
 
           res.on('end', function () {
-            if (successcb != null) {
-              successcb(JSON.parse(resData));
-            }
+            (successcb || deferred.resolve).call(deferred, JSON.parse(resData));
           });
           
         });
         
         // handle request errors
-        if (errorcb != null) {
-          req.on('error', errorcb);
-        }
-          
+        req.on('error', function(error) {
+          (errorcb || deferred.reject).call(deferred, error);
+        });
+
         req.write(data);
-        req.end();        
+        req.end();
+
+        return deferred.promise;
       },
       
       /**
@@ -363,8 +366,9 @@
             */
       put: function (path, data, successcb, errorcb) {
         var req,
-            opt = getOptions();
-        
+            opt = getOptions(),
+            deferred = Promise.defer();
+
         opt.host = host;
         opt.port = port;
         opt.path = getPath(path);
@@ -379,20 +383,20 @@
           });
 
           res.on('end', function () {
-            if (successcb != null) {
-              successcb(JSON.parse(resData));
-            }
+            (successcb || deferred.resolve).call(deferred, JSON.parse(resData));
           });
           
         });
         
         // handle request errors
-        if (errorcb != null) {
-          req.on('error', errorcb);
-        }
-          
+        req.on('error', function(error) {
+          (errorcb || deferred.reject).call(deferred, error);
+        });
+
         req.write(data);
-        req.end();        
+        req.end();
+
+        return deferred.promise;
       },
       
       /**
@@ -408,8 +412,9 @@
             */
       del: function (path, data, successcb, errorcb) {
         var req,
-            opt = getOptions();
-        
+            opt = getOptions(),
+            deferred = Promise.defer();
+
         opt.host = host;
         opt.port = port;
         opt.path = getPath(path);
@@ -424,20 +429,20 @@
           });
 
           res.on('end', function () {
-            if (successcb != null) {
-              successcb(JSON.parse(resData));
-            }
+            (successcb || deferred.resolve).call(deferred, JSON.parse(resData));
           });
           
         });
           
         // handle request errors
-        if (errorcb != null) {
-          req.on('error', errorcb);
-        }
-          
+        req.on('error', function(error) {
+          (errorcb || deferred.reject).call(deferred, error);
+        });
+
         req.write(data);
-        req.end();        
+        req.end();
+
+        return deferred.promise;
       },
       
       /**
@@ -454,25 +459,26 @@
             */
       head: function (path, data, successcb, errorcb) {
         var req,
-            opt = getOptions();
-          
+            opt = getOptions(),
+            deferred = Promise.defer();
+
         opt.host = host;
         opt.port = port;
         opt.path = getPath(path) + '?' + querystring.stringify(data);
         opt.method = 'HEAD';
           
         req = protocol.request(opt, function (res) {
-          if (successcb != null) {
-            successcb(res.headers);
-          }
+          (successcb || deferred.resolve).call(deferred, res.headers);
         });
         
         // handle request errors
-        if (errorcb != null) {
-          req.on('error', errorcb);
-        }
-          
-        req.end();        
+        req.on('error', function(error) {
+          (errorcb || deferred.reject).call(deferred, error);
+        });
+
+        req.end();
+
+        return deferred.promise;
       }
     };
   };

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "prepublish": "cp dist/elastic.js dist/elastic-node-client.js ."
   },
   "dependencies": {
-    "colors": "~0.6"
+    "colors": "~0.6",
+    "bluebird": "~0.11.5-1"
   },
   "devDependencies": {
     "grunt": "~0.4.1",

--- a/src/clients/elastic-node-client.js
+++ b/src/clients/elastic-node-client.js
@@ -11,7 +11,8 @@
     http = require('http'),
     https = require('https'),
     querystring = require('querystring'),
-    
+    Promise = require('bluebird'),
+
     // save reference to global object
     // `window` in browser
     // `exports` on server
@@ -270,8 +271,9 @@
             */
       get: function (path, data, successcb, errorcb) {
         var req,
-            opt = getOptions();
-          
+            opt = getOptions(),
+            deferred = Promise.defer();
+
         opt.host = host;
         opt.port = port;
         opt.path = getPath(path) + '?' + querystring.stringify(data);
@@ -286,19 +288,19 @@
           });
 
           res.on('end', function () {
-            if (successcb != null) {
-              successcb(JSON.parse(resData));
-            }
+            (successcb || deferred.resolve).call(deferred, JSON.parse(resData));
           });
-          
+
         });
-        
+
         // handle request errors
-        if (errorcb != null) {
-          req.on('error', errorcb);
-        }
-        
+        req.on('error', function(error) {
+          (errorcb || deferred.reject).call(deferred, error);
+        });
+
         req.end();
+
+        return deferred.promise;
       },
       
       /**
@@ -314,8 +316,9 @@
             */
       post: function (path, data, successcb, errorcb) {
         var req,
-            opt = getOptions();
-        
+            opt = getOptions(),
+            deferred = Promise.defer();
+
         opt.host = host;
         opt.port = port;
         opt.path = getPath(path);
@@ -330,20 +333,20 @@
           });
 
           res.on('end', function () {
-            if (successcb != null) {
-              successcb(JSON.parse(resData));
-            }
+            (successcb || deferred.resolve).call(deferred, JSON.parse(resData));
           });
           
         });
         
         // handle request errors
-        if (errorcb != null) {
-          req.on('error', errorcb);
-        }
-          
+        req.on('error', function(error) {
+          (errorcb || deferred.reject).call(deferred, error);
+        });
+
         req.write(data);
-        req.end();        
+        req.end();
+
+        return deferred.promise;
       },
       
       /**
@@ -359,8 +362,9 @@
             */
       put: function (path, data, successcb, errorcb) {
         var req,
-            opt = getOptions();
-        
+            opt = getOptions(),
+            deferred = Promise.defer();
+
         opt.host = host;
         opt.port = port;
         opt.path = getPath(path);
@@ -375,20 +379,20 @@
           });
 
           res.on('end', function () {
-            if (successcb != null) {
-              successcb(JSON.parse(resData));
-            }
+            (successcb || deferred.resolve).call(deferred, JSON.parse(resData));
           });
           
         });
         
         // handle request errors
-        if (errorcb != null) {
-          req.on('error', errorcb);
-        }
-          
+        req.on('error', function(error) {
+          (errorcb || deferred.reject).call(deferred, error);
+        });
+
         req.write(data);
-        req.end();        
+        req.end();
+
+        return deferred.promise;
       },
       
       /**
@@ -404,8 +408,9 @@
             */
       del: function (path, data, successcb, errorcb) {
         var req,
-            opt = getOptions();
-        
+            opt = getOptions(),
+            deferred = Promise.defer();
+
         opt.host = host;
         opt.port = port;
         opt.path = getPath(path);
@@ -420,20 +425,20 @@
           });
 
           res.on('end', function () {
-            if (successcb != null) {
-              successcb(JSON.parse(resData));
-            }
+            (successcb || deferred.resolve).call(deferred, JSON.parse(resData));
           });
           
         });
           
         // handle request errors
-        if (errorcb != null) {
-          req.on('error', errorcb);
-        }
-          
+        req.on('error', function(error) {
+          (errorcb || deferred.reject).call(deferred, error);
+        });
+
         req.write(data);
-        req.end();        
+        req.end();
+
+        return deferred.promise;
       },
       
       /**
@@ -450,25 +455,26 @@
             */
       head: function (path, data, successcb, errorcb) {
         var req,
-            opt = getOptions();
-          
+            opt = getOptions(),
+            deferred = Promise.defer();
+
         opt.host = host;
         opt.port = port;
         opt.path = getPath(path) + '?' + querystring.stringify(data);
         opt.method = 'HEAD';
           
         req = protocol.request(opt, function (res) {
-          if (successcb != null) {
-            successcb(res.headers);
-          }
+          (successcb || deferred.resolve).call(deferred, res.headers);
         });
         
         // handle request errors
-        if (errorcb != null) {
-          req.on('error', errorcb);
-        }
-          
-        req.end();        
+        req.on('error', function(error) {
+          (errorcb || deferred.reject).call(deferred, error);
+        });
+
+        req.end();
+
+        return deferred.promise;
       }
     };
   };


### PR DESCRIPTION
Added promise support to the node client, without sacrificing backwards compatibility.

``` coffeescript
ejs.Request()
  .indices("tweets")
  .types("tweet")
  .query(ejs.TermQuery("user", "kimchi"))
  .doSearch()
  .then (results) ->
      console.log(results)
```

Note that you cannot use both callbacks and deferreds; If a callback is passed in, it will be used instead of the deferred's callback.
