### PR TITLE
Fix highlighter type values

### DIFF
--- a/src/search/Highlight.js
+++ b/src/search/Highlight.js
@@ -341,8 +341,9 @@
             to a specific field by passing the field name in to the
             <code>oField</code> parameter.  Valid values for order are:
 
-            fast-vector-highlighter - the fast vector based highligher
-            highlighter - the slower plain highligher
+            plain - the slower Lucene standard highligher
+            postings - the postings highligher
+            fvh - the fast vector based highligher
 
             @member ejs.Highlight
             @param {String} t The highligher.
@@ -357,7 +358,7 @@
         }
 
         t = t.toLowerCase();
-        if (t === 'fast-vector-highlighter' || t === 'highlighter' ||
+        if (t === 'fvh' || t === 'plain' ||
             t === 'postings') {
           addOption(oField, 'type', t);
         }


### PR DESCRIPTION
As defined at the [ElasticSearch highlighting reference](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-highlighting.html#_force_highlighter_type), the valid values for the highlighter `type` field are `plain`, `postings` and `fvh`.
