### PR TITLE
Make elastic.js work as an npm package again

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,9 @@
     "name": "FullScale Labs, LLC",
     "url": "https://github.com/fullscale/elastic.js/blob/master/AUTHORS"
   },
-  "main": "elastic.js",
+  "main": "dist/elastic.js",
   "scripts": {
-    "test": "grunt nodeunit",
-    "prepublish": "cp dist/elastic.js ."
+    "test": "grunt nodeunit"
   },
   "dependencies": {
     "elasticsearch": "*",


### PR DESCRIPTION
Updated package.json to refer to dist/elastic.js instead of the non-existant ./elastic.js

Resolves issues #60 and #63.
